### PR TITLE
Update license attribute

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -8,12 +8,7 @@
     "type": "git",
     "url": "git://github.com/masterdipesh/node-sms"
   },
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/masterdipesh/node-sms/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "main": "./lib/node-sms.js",
   "keywords": [
     "sms",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
